### PR TITLE
Add note on macOS fix in App Installation Guide

### DIFF
--- a/source/installing_systems/installation_app.rst
+++ b/source/installing_systems/installation_app.rst
@@ -110,6 +110,22 @@ which will install all required packages for our project. When it's done, execut
 
 to get support for *scss*.
 
+.. note::
+  On newer versions of macOS (High Sierra or later) you might need to perform some extra steps.
+
+  CocoaPods needs to be installed and setup.
+  In ``/app`` run::
+    sudo gem install cocoapods
+    pod setup
+  To avoid more manual setup use Node version ``11.x``.
+  In the current setup Node versions ``12.x``, ``13.x``, ``14.x`` and ``15.x`` all require different workarounds on macOS.
+
+  You will also need to
+  clear and reinstall the phonegap push plugin for ios::
+    rm -r plugins/phonegap-plugin-push
+    phonegap cordova platform rm ios
+    phonegap cordova platform add ios
+
 ==================
 Running the server
 ==================


### PR DESCRIPTION
Fix for macOS Big Sur installation error.

Note: This creates some untracked dot-files in `plugins/phonegap-plugin-push` but solves all installation errors.

### Preview:
<img width="567" alt="Skärmavbild 2020-12-21 kl  14 49 34" src="https://user-images.githubusercontent.com/10536269/102783774-c04a0380-439b-11eb-96c7-d6afe38c8b43.png">
